### PR TITLE
How to use ApplyROI with multiple ROIs

### DIFF
--- a/+nirs/+modules/ApplyROI.m
+++ b/+nirs/+modules/ApplyROI.m
@@ -42,8 +42,19 @@ classdef ApplyROI < nirs.modules.AbstractModule
                    
                     dataROI(i,1)=nirs.util.roiAverage(dataChannel(i),listOfROIs,[],[],obj.weighted);
                 else
-
-                    [~,dataROI(i,1)]=nirs.util.roiAverage(dataChannel(i),listOfROIs,[],[],obj.weighted);
+                    if size(listOfROIs,1) == 1
+                        [~,dataROI(i,1)]=nirs.util.roiAverage(dataChannel(i),listOfROIs,[],[],obj.weighted);
+                    else
+                        ROIS = {};
+                        Names = {};
+                        for ROI_idx = 1:size(listOfROIs,1)
+                            source = listOfROIs(ROI_idx,:).source{1}';
+                            detector = listOfROIs(ROI_idx,:).detector{1}';
+                            ROIS{ROI_idx} = table(source, detector);
+                            Names{ROI_idx} = listOfROIs(ROI_idx,:).Name{1};
+                        end
+                        [~,dataROI(i,1)]=nirs.util.roiAverage(dataChannel(i),ROIS,Names,[],obj.weighted);
+                    end
                 end
             end
             

--- a/+nirs/+testing/+unittests/TestROI.m
+++ b/+nirs/+testing/+unittests/TestROI.m
@@ -92,6 +92,19 @@ classdef TestROI < matlab.unittest.TestCase
             obj.verifyLessThan(sum(res.covb(:)-true_covb(:)),10^-10);
             
         end
+        
+        function testROI_multiple( obj )
+            % Verify that ROI calculation can be applied to multiple
+            % regions
+
+            % Module calculation
+            job = nirs.modules.ApplyROI();
+            job.listOfROIs(1,:) = array2table({[1 1],[1 2],'First'});
+            job.listOfROIs(2,:) = array2table({[1 1],[1 2],'Second'});
+            job.weighted = true;          
+            res = job.run( obj.data1 );
+        
+        end
 
     end
     


### PR DESCRIPTION
Dear Professor Huppert,

I recently updated to the latest commit and found that my usage of `ApplyROI` no longer works. I have been unable to determine how long ago the change happened based on commit hashes (I assume due to the mercurial git changeover) and I foolishly had deleted my previous mercurial download 🤦.

When I run `ApplyROI` with multiple ROIs ([following the format in docs](https://github.com/huppertt/nirs-toolbox/blob/master/%2Bnirs/%2Bmodules/ApplyROI.m#L4)) I get the following error:
```Matlab
Undefined function 'isnan' for input arguments of type 'cell'.
    
Error in nirs.util.ROIhelper (line 51)
    if(any(all([isnan(R{idx}.detector) isnan(R{idx}.source)],2)))
```

I have suggested two code changes in the pull request. First, I added a unit test to demonstrate the issue I encountered. Second, I have proposed a solution that modifies the `ApplyROI` input format to be suitable for `roiAverage`. I decided to modify the `ApplyROI` function as this seemed the most backwards compatible solution (no change to documentation required).

It may also be that I have misunderstood how to use the `ApplyROI` function, if so I would be happy to update the documentation if you can inform me of a better way to specify multiple ROIs.

Thanks for the great package,
Rob