### PR TITLE
Typo in the ShortDistanceFilter.m

### DIFF
--- a/+advanced/+nirs/+modules/ShortDistanceFilter.m
+++ b/+advanced/+nirs/+modules/ShortDistanceFilter.m
@@ -25,8 +25,8 @@ classdef ShortDistanceFilter < nirs.modules.AbstractModule
                 if(obj.splittypes)
                     types=unique(data(i).probe.link.type);
                     for tI=1:length(types)
-                        channelLst=find(data(i).probe.link.ShortSeperation & ismember(data(i).probe.link.type,types(i)));
-                        lst=find(~data(i).probe.link.ShortSeperation & ismember(data(i).probe.link.type,types(i)));
+                        channelLst=find(data(i).probe.link.ShortSeperation & ismember(data(i).probe.link.type,types(tI)));
+                        lst=find(~data(i).probe.link.ShortSeperation & ismember(data(i).probe.link.type,types(tI)));
                         d = data(i).data;
                         
                         SS = d(:,channelLst);


### PR DESCRIPTION
Dear Professor Huppert,
I noticed a typo in the mentioned function script. The index for _types_ should be "tI" instead of "i"—the "i" indexing the number of subjects. 

Thank you for this great tool.

Best regards,
Steven  


 