### PR TITLE
ChannelStatsROC changes for Aux regressors

### DIFF
--- a/+nirs/+modules/RemoveAuxFromStats.m
+++ b/+nirs/+modules/RemoveAuxFromStats.m
@@ -1,0 +1,30 @@
+classdef RemoveAuxFromStats < nirs.modules.AbstractModule
+    %% Remove Short Seperation - removes channels from probe/data
+   
+  
+    
+    methods
+        function obj = RemoveAuxFromStats( prevJob )
+            obj.name = 'RemoveAuxFromStats';
+            
+            if nargin > 0
+                obj.prevJob = prevJob;
+            end
+        end
+        
+        function data = runThis( obj, data )
+            for i = 1:numel(data)
+                if(isa(data,'nirs.core.ChannelStats'))
+                        lst=~cellfun('isempty', strfind(data(i).variables.cond,'Aux'));
+                        data(i).variables(lst,:)=[];
+                        data(i).beta(lst)=[];
+                        data(i).covb(lst,:)=[];
+                        data(i).covb(:,lst)=[];
+                        
+                    end
+                end
+            end
+        end
+    end
+    
+

--- a/+nirs/+testing/ChannelStatsROC.m
+++ b/+nirs/+testing/ChannelStatsROC.m
@@ -97,14 +97,14 @@ classdef ChannelStatsROC
         
         function obj = run(obj, iter)
             if ~isempty(obj.dataset)
-                if (~ismember("data", fieldnames(obj.dataset)))
-                    error("No data feild in dataset!")
+                if (~ismember('data', fieldnames(obj.dataset)))
+                    error('No data feild in dataset!')
                 end
-                if (~ismember("truth", fieldnames(obj.dataset)))
-                    error("No truth feild in dataset!")
+                if (~ismember('truth', fieldnames(obj.dataset)))
+                    error('No truth feild in dataset!')
                 end
                 if (iter > length(obj.dataset.data))
-                    warning("Requested number of iterations is greater than data size. Discard excessive iterations.");
+                    warning('Requested number of iterations is greater than data size. Discard excessive iterations.');
                     iter = length(obj.dataset.data);
                 end
             end
@@ -151,6 +151,11 @@ classdef ChannelStatsROC
                            job=nirs.modules.RemoveShortSeperations;
                            stats=job.run(stats);
                        end
+                   end
+                   
+                   if ~isempty(strfind(stats(1).variables.cond,'Aux'))
+                       job=nirs.modules.RemoveAuxFromStats;
+                       stats=job.run(stats);
                    end
                    
                    if(length(truth)>height(data(1).probe.link))


### PR DESCRIPTION
Problem: Simulations failing due to Aux regressors inclusion in the stats table, creating a mismatch between ground truth and condition lengths.
Solution: Created script similar to RemoverShortSeperations to remove the Aux regressors from the stats output.