### PR TITLE
Fix for changing stimulus duration using change_stimulus_duration and other changes

### DIFF
--- a/+nirs/+bids/loadBIDS.m
+++ b/+nirs/+bids/loadBIDS.m
@@ -82,7 +82,7 @@ for i=1:length(json_files);
             end
          end
     else
-        error('need to code this');
+        warning('Unable to parse %s, this json format may not be specifically supported by NIRS toolbox at this time',json_files(i).name);
     end
 
     

--- a/+nirs/+design/change_stimulus_duration.m
+++ b/+nirs/+design/change_stimulus_duration.m
@@ -23,6 +23,8 @@ end
 
 for i=1:length(stimname)
 
-    data.stimulus.(stimname{i}).dur(:)=duration(i);
+    if(isfield(data.stimulus,stimname{i}))
+        data.stimulus.(stimname{i}).dur(:)=duration(i);
+    end
     
 end

--- a/+nirs/+design/change_stimulus_duration.m
+++ b/+nirs/+design/change_stimulus_duration.m
@@ -22,17 +22,7 @@ if(length(duration)<length(stimname))
 end
 
 for i=1:length(stimname)
-      
-    stimtable=nirs.createStimulusTable(data);
-    stimtable=stimtable(1,:);
-    stimtable.FileIdx=NaN;
-    st=stimtable.(stimname{i});
-    st.onset=NaN;
-    st.dur=duration(i);
-    stimtable.(stimname{i})=st;
-    
-    job=nirs.modules.ChangeStimulusInfo;
-    job.ChangeTable=stimtable;
-    data=job.run(data);
+
+    data.stimulus.(stimname{i}).dur(:)=duration(i);
     
 end

--- a/+nirs/+design/change_stimulus_duration.m
+++ b/+nirs/+design/change_stimulus_duration.m
@@ -1,5 +1,17 @@
 function data=change_stimulus_duration(data,stimname,duration)
 % This function will change the duration of a stimulus in a data variable
+%   If stimname is empty, duration for all stimuli will be changed
+%       ex: change_stimulus_duration(data,[],10)
+%           sets stimuli in data ('A' and 'B') to 10
+%       ex: change_stimulus_duration(data,{'A'},10)
+%           sets stimulu in data ('A') to 10, leaves B
+%
+%   If an array of data objects is passed through, stimulus length is
+%       changed for each object in data
+
+if(nargin<3)
+    error('New stimulus duration must be provided');
+end
 
 
 if(length(data)>1)

--- a/+nirs/+modules/AddDemographics.m
+++ b/+nirs/+modules/AddDemographics.m
@@ -41,31 +41,47 @@ classdef AddDemographics < nirs.modules.AbstractModule
             else
                 lst = find(~ismember(colNames,obj.varToMatch));
             end
+
+            idx=[];
+            varToMatchA_idx=find(strcmpi(obj.demoTable.Properties.VariableNames,obj.varToMatch));
+            if(isempty(varToMatchA_idx))
+                if obj.allowMissing
+                    warning('All entries missing in demographics table for %s!',obj.varToMatch);
+                else
+                    error('All entries missing in demographics table for %s!',obj.varToMatch);
+                end
+            end
+            
             
             for i = 1:numel(data)
+                    
 
                 if ~iscell(obj.varToMatch)
                     % Make this case-insensitive
-                    varToMatchA=obj.demoTable.Properties.VariableNames{find(ismember(lower(obj.demoTable.Properties.VariableNames),lower(obj.varToMatch)))};
-                     % row idx of demo table
-
-                     if(isstr(data(i).demographics(obj.varToMatch)) | iscellstr(data(i).demographics(obj.varToMatch)))
-                    idx = find( strcmpi( obj.demoTable.(varToMatchA), data(i).demographics(obj.varToMatch) ) );
-                     else
-                         idx=find(obj.demoTable.(varToMatchA)==data(i).demographics(obj.varToMatch) );
-                     end
+                    if(~isempty(varToMatchA_idx))
+                        varToMatchA=obj.demoTable.Properties.VariableNames{varToMatchA_idx};
+                         % row idx of demo table
+    
+                         if(isstr(data(i).demographics(obj.varToMatch)) | iscellstr(data(i).demographics(obj.varToMatch)))
+                            idx = find( strcmpi( obj.demoTable.(varToMatchA), data(i).demographics(obj.varToMatch) ) );
+                         else
+                             idx=find(obj.demoTable.(varToMatchA)==data(i).demographics(obj.varToMatch) );
+                         end
+                    end
                      
                 else
-                    varToMatchA=obj.demoTable.Properties.VariableNames(find(ismember(lower(obj.demoTable.Properties.VariableNames),lower(obj.varToMatch))));
-                    % row idx of demo table
-                    T = cell2table(data(i).demographics(obj.varToMatch),'VariableNames',varToMatchA);
-                  %  [~,idx] = ismember(T,obj.demoTable(:,varToMatchA));
-                    idx = find(ismember(obj.demoTable(:,varToMatchA),T));
+                    if(~isempty(varToMatchA_idx))
+                        varToMatchA=obj.demoTable.Properties.VariableNames(find(ismember(lower(obj.demoTable.Properties.VariableNames),lower(obj.varToMatch))));
+                        % row idx of demo table
+                        T = cell2table(data(i).demographics(obj.varToMatch),'VariableNames',varToMatchA);
+                      %  [~,idx] = ismember(T,obj.demoTable(:,varToMatchA));
+                        idx = find(ismember(obj.demoTable(:,varToMatchA),T));
+                    end
                 end
                 
                
                 
-                if(isempty(idx))
+                if(isempty(idx)&&~isempty(varToMatchA_idx))
                     if obj.allowMissing
                         warning(['Missing entry: ' data(i).demographics(obj.varToMatch)]);
                     else

--- a/+nirs/+util/snirf2data.m
+++ b/+nirs/+util/snirf2data.m
@@ -217,7 +217,7 @@ for i=1:length(snirf.nirs)
 
         
         tmpdata(ii).probe.optodes_registered=table(Name,X,Y,Z,Type,Units);
-        tmpdata(ii).probe.optodes=table(Name,X,Y,Z,Type,Units);
+        tmpdata(ii).probe.optodes=table(Name,X,Y,Z*0,Type,Units);
         
         
         fds=fields(snirf.nirs(i).metaDataTags);


### PR DESCRIPTION
This PR includes several fixes
1) uses new syntax to assign stimulus duration within the change_stimulus_duration function
2) Modifies loadBIDS error message when loading json to make it more informative and warn instead of crashing
3) Modify AddDemographics to not fail if var2match is completely missing, but missing is allowed (as in case for missing UUID in demographics table)
4) Change behavior of +nirs/+util/snirf2data.m to 
    a) transpose source/detector/landmark coordinates if not presented directly
    b) express preference for Pos as best, then xxxPos3D field as next best, then Pos2D in that order
    c) Rename sd labels to 'Source-#'/ 'Detector-#' if number is provided. Otherwise autogenerated labels are used
    d) consolidated behaviors for source, detector, and landmarks so that all position types are treated in the same manner for rotation etc
    