### PR TITLE
Fresh snirf fixes

### DIFF
--- a/+nirs/+bids/loadBIDS.m
+++ b/+nirs/+bids/loadBIDS.m
@@ -4,14 +4,17 @@ if(nargin<2)
     verbose=false;
 end
 
+% Get a list of every snirf  file
 snirf_files = rdir(fullfile(folder,'**','*.snirf'));
 
+% Load each snirf file
 for i=1:length(snirf_files)
     if(verbose)
         disp(['Loading ' snirf_files(i).name]);
     end
     try
         data(i,1)=nirs.io.loadSNIRF(snirf_files(i).name);
+        data(i,1)=add_bids_session(data(i,1), snirf_files(i).folder, verbose);
     catch
         warning(['failed to load: ' snirf_files(i).name]);
     end
@@ -23,8 +26,7 @@ json_files=rdir(fullfile(folder,'**','*.json'));
 [~,id]=sort(cellfun(@(x)length(x),{json_files.folder}));
 json_files=json_files(id);
 
-
-for i=1:length(json_files);
+for i=1:length(json_files)
     
     if(verbose)
         disp(['applying JSON file: ' json_files(i).name]);
@@ -87,4 +89,37 @@ for i=1:length(json_files);
 
     
     
-end;
+end
+
+end
+
+% Add session from BIDS structure to metadata
+function data = add_bids_session(data, nirs_folder, verbose)
+
+% make sure we haven't already added a session
+if iskey(data.demographics, 'session')
+    return
+end
+
+% remove trailing file separator
+if nirs_folder(end) == filesep
+    nirs_folder = nirs_folder(1:end-1);
+end
+
+% validate folder name is according to BIDS spec
+folder_parts = strsplit(nirs_folder, filesep);
+session_folder = folder_parts{end-1};
+if ~startsWith(session_folder, 'ses-')
+    if(verbose)
+        disp(['Session folder does not look like BIDS format: ', session_folder]);
+    end
+    return
+end
+
+% grab session name
+session = extractAfter(session_folder, 'ses-');
+
+% add to demographics
+data.demographics('session') = session;
+
+end

--- a/+nirs/+design/change_stimulus_duration.m
+++ b/+nirs/+design/change_stimulus_duration.m
@@ -20,38 +20,18 @@ if(length(data)>1)
     end
     return
 end
-
 if(isempty(stimname))
     stimname=unique(nirs.getStimNames(data));
 end
-
 if(~iscellstr(stimname))
     stimname={stimname};
 end
-
 if(length(duration)<length(stimname))
     duration=duration(1)*ones(length(stimname),1);
 end
-
 for i=1:length(stimname)
-<<<<<<< Updated upstream
-
-    if(isfield(data.stimulus,stimname{i}))
+    if(iskey(data.stimulus,stimname{i}))
         data.stimulus.(stimname{i}).dur(:)=duration(i);
     end
-=======
-      
-    stimtable=nirs.createStimulusTable(data);
-    stimtable=stimtable(1,:);
-    stimtable.FileIdx=NaN;
-    st=stimtable.(stimname{i});
-    %st.onset=NaN;
-    st.dur(:)=duration(i);
-    stimtable.(stimname{i})=st;
-    
-    job=nirs.modules.ChangeStimulusInfo;
-    job.ChangeTable=stimtable;
-    data=job.run(data);
->>>>>>> Stashed changes
     
 end

--- a/+nirs/+util/snirf2data.m
+++ b/+nirs/+util/snirf2data.m
@@ -83,7 +83,7 @@ for i=1:length(snirf.nirs)
 
             % if pos3d for field exists, check if the size matches the
             % known size, if it needs to be rotated, rotate it
-            %    if nominal position field doesn't exist, use pos3D
+            % if nominal position field doesn't exist, use pos3D
             if(isfield(snirf.nirs(i).probe,pos3DField))
                 sz=size(snirf.nirs(i).probe.(pos3DField));
                 if(isnan(n))
@@ -138,7 +138,7 @@ for i=1:length(snirf.nirs)
 
                 if(rotateFields&&isfield(snirf.nirs(i).probe,pos3DField)&&n==3)
                     % Catch corner case where 2D field is rotated, but 3D
-                        % field was assigned but not rotated originally
+                    % field was assigned but not rotated originally
                     snirf.nirs(i).probe.(pos3DField)=snirf.nirs(i).probe.(pos3DField)';
 
                     if(~posFieldPreexists)
@@ -174,7 +174,7 @@ for i=1:length(snirf.nirs)
 
             if(~isfield(snirf.nirs(i).probe,posLabelField)&&~strcmp(posType,'landmark'))
                 for j=1:n
-                    snirf.nirs(i).probe.(posLabelField){j,1}=[posCapital+'-' num2str(j)];
+                    snirf.nirs(i).probe.(posLabelField){j}=[posCapital+'-' num2str(j)];
                 end
             elseif(isfield(snirf.nirs(i).probe,posLabelField)&&~strcmp(posType,'landmark'))
                 snirf.nirs(i).probe.(posOrigLabelField)=snirf.nirs(i).probe.(posLabelField);
@@ -184,7 +184,7 @@ for i=1:length(snirf.nirs)
                     if(isempty(newNumStr))
                         error('%s label must contain a number',posType);
                     end
-                    snirf.nirs(i).probe.(posLabelField){j,1}=sprintf('%s-%s',posCapital,newNumStr); %NIRS toolbox requires Source-#, Detector-# format
+                    snirf.nirs(i).probe.(posLabelField){j}=sprintf('%s-%s',posCapital,newNumStr); %NIRS toolbox requires Source-#, Detector-# format
                 end
             end
 


### PR DESCRIPTION
Hello,

I'm currently using the toolbox to run some analyses for the OpenFNIRS FRESH project, https://openfnirs.org/data/fresh/
I ran into some BIDS loading issues and a stimulus issue and made some suggested fixes.

To run the entire pipeline properly I also had to revert 3e9132c6f901e78d46fa9a9104b76d6471f39015 (to get the 3D positions working, but I don't want to mess with that behavior here) plus handle some things with unit conversion and visualization (e.g. the 3D mesh is in mm, while this data is in m). I'm using some quick and dirty fixes for those but could write proper conversion handling etc later.

Thanks for all your work with the toolbox!