### PR TITLE
Update snirf2data.m

### DIFF
--- a/+nirs/+util/snirf2data.m
+++ b/+nirs/+util/snirf2data.m
@@ -203,7 +203,7 @@ for i=1:length(snirf.nirs)
 
             if(~isfield(snirf.nirs(i).probe,posLabelField)&&~strcmp(posType,'landmark'))
                 for j=1:n
-                    snirf.nirs(i).probe.(posLabelField){j}=[posCapital+'-' num2str(j)];
+                    snirf.nirs(i).probe.(posLabelField){j}=[posCapital '-' num2str(j)];
                 end
             elseif(isfield(snirf.nirs(i).probe,posLabelField)&&~strcmp(posType,'landmark'))
                 snirf.nirs(i).probe.(posOrigLabelField)=snirf.nirs(i).probe.(posLabelField);


### PR DESCRIPTION
there was a '+' rather than a space in line 206 that was causing matlab to output the unicode characters rather than stored strings. changed line from: 

snirf.nirs(i).probe.(posLabelField){j}=[posCapital+'-' num2str(j)];

to:

snirf.nirs(i).probe.(posLabelField){j}=[posCapital '-' num2str(j)];