### PR TITLE
Rehash dictionary on item removal

### DIFF
--- a/external/Dictionary/Dictionary.m
+++ b/external/Dictionary/Dictionary.m
@@ -113,6 +113,8 @@ classdef Dictionary
                    obj.indices(lst) = obj.indices(lst) - 1;
                end
             end
+
+            obj = obj.rehash();
             
         end
         
@@ -182,6 +184,30 @@ classdef Dictionary
     methods (Hidden = true)
         % put new items
         function obj = put( obj, newKeys, newVals )
+
+            if(isnumeric(newVals)&&isempty(newVals))
+                if ischar(newKeys)
+                    newKeys = {newKeys};
+                end
+                
+                for k = 1:length(newKeys)
+                   [i, keyexists] = obj.getindex(newKeys{k});
+                   if keyexists
+                       idx = obj.indices(i);
+                       
+                       obj.keys(idx)    = [];
+                       obj.values(idx)  = [];
+                       obj.indices(i)   = 0;
+    
+                       lst = obj.indices > idx;
+                       obj.indices(lst) = obj.indices(lst) - 1;
+                   end
+                end
+
+                obj = obj.rehash();
+
+                return;
+            end
             
             if ~iscell(newKeys)
                 newKeys = {newKeys};
@@ -432,8 +458,8 @@ classdef Dictionary
             end
             obj.indices = zeros(obj.TABLE_SIZE,1,'uint32');
             for k = 1:length(obj.keys)
-                   i = obj.getindex(obj.keys{k});
-                   obj.indices(i) = k;
+               i = obj.getindex(obj.keys{k});
+               obj.indices(i) = k;
             end
         end
     end


### PR DESCRIPTION
Instructs dictionary to rehash when removing items (prevents hash collisions with similarly named stimuli)

+ allow items to be removed from dictionary by assigning them to []

ex: raw(123).stimulus.('stimulusIwantToRemove)=[];